### PR TITLE
Add Markdown-based blog pages

### DIFF
--- a/site.diogocosta.dev/Blog/2024-06-12-transformando-carreira.md
+++ b/site.diogocosta.dev/Blog/2024-06-12-transformando-carreira.md
@@ -1,0 +1,7 @@
+# Transformando sua carreira em empresa
+
+Muitos devs passam anos entregando código… para os outros.
+
+Mas poucos param para construir algo próprio.
+
+Aqui, ensino como mudar isso com estrutura, produto e visão.

--- a/site.diogocosta.dev/Controllers/BlogController.cs
+++ b/site.diogocosta.dev/Controllers/BlogController.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Mvc;
+using Markdig;
+
+namespace site.diogocosta.dev.Controllers;
+
+public class BlogController : Controller
+{
+    public IActionResult Post(string slug)
+    {
+        if (string.IsNullOrWhiteSpace(slug))
+            return NotFound();
+
+        var basePath = Path.Combine(Directory.GetCurrentDirectory(), "Blog");
+        var fullPath = Path.Combine(basePath, $"{slug}.md");
+
+        if (!System.IO.File.Exists(fullPath))
+            return NotFound();
+
+        var markdown = System.IO.File.ReadAllText(fullPath);
+        var html = Markdown.ToHtml(markdown);
+
+        ViewData["Content"] = html;
+        ViewData["Title"] = slug.Replace("-", " ").ToUpperInvariant();
+
+        return View("Post");
+    }
+}

--- a/site.diogocosta.dev/Program.cs
+++ b/site.diogocosta.dev/Program.cs
@@ -21,6 +21,11 @@ app.UseRouting();
 app.UseAuthorization();
 
 app.MapControllerRoute(
+    name: "blog",
+    pattern: "blog/{slug}",
+    defaults: new { controller = "Blog", action = "Post" });
+
+app.MapControllerRoute(
     name: "default",
     pattern: "{controller=Home}/{action=Index}/{id?}");
 

--- a/site.diogocosta.dev/Views/Blog/Post.cshtml
+++ b/site.diogocosta.dev/Views/Blog/Post.cshtml
@@ -1,0 +1,12 @@
+@{
+    Layout = "_Layout";
+    var html = ViewData["Content"]?.ToString() ?? "";
+    var title = ViewData["Title"]?.ToString() ?? "Post";
+}
+
+<div class="container py-5">
+    <h1>@title</h1>
+    <article class="prose max-w-none">
+        @Html.Raw(html)
+    </article>
+</div>

--- a/site.diogocosta.dev/site.diogocosta.dev.csproj
+++ b/site.diogocosta.dev/site.diogocosta.dev.csproj
@@ -6,8 +6,13 @@
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
-    <ItemGroup>
+  <ItemGroup>
       <Folder Include="wwwroot\img\testemunhos\" />
-    </ItemGroup>
+      <Folder Include="Blog\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Markdig" Version="0.41.2" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add Markdig as dependency
- configure blog route in `Program.cs`
- implement `BlogController` for markdown posts
- add Razor view for blog post
- create sample post `2024-06-12-transformando-carreira.md`
- refine controller logic and view layout

## Testing
- `dotnet build site.diogocosta.dev/site.diogocosta.dev.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aead1b284832e86b58410ecdc814d