### PR TITLE
fix: Corrige a formatação do país no serviço de download de PDF

### DIFF
--- a/site.diogocosta.dev/Servicos/PdfDownloadService.cs
+++ b/site.diogocosta.dev/Servicos/PdfDownloadService.cs
@@ -183,7 +183,7 @@ namespace site.diogocosta.dev.Servicos
 
                 var localizacao = new LocalizacaoInfo
                 {
-                    Pais = !string.IsNullOrWhiteSpace(pais) ? pais.Trim() : null,
+                    Pais = !string.IsNullOrWhiteSpace(pais) ? pais.Trim().ToUpperInvariant().Substring(0, Math.Min(2, pais.Trim().Length)) : null,
                     Cidade = !string.IsNullOrWhiteSpace(cidade) ? cidade.Trim() : null
                 };
 


### PR DESCRIPTION
- Atualiza a lógica para definir o país, garantindo que o valor seja convertido para letras maiúsculas e limitado a dois caracteres, se aplicável.